### PR TITLE
Update Catalog HTML and FO Transforms for NIST SP 800-53 Revision 5.2 Release

### DIFF
--- a/publish/nist-emulation/rev5update-emulator_fo.xsl
+++ b/publish/nist-emulation/rev5update-emulator_fo.xsl
@@ -180,6 +180,14 @@ TO DO:
     </fo:block>
   </xsl:template>
   
+  <!--special handling for control enhancements (nested controls)-->
+  <xsl:template priority="5" match="div[contains-token(@class,'control')]//div[contains-token(@class,'control')]//summary[contains-token(@class,'h3')]">
+    <fo:block font-family="{ $display-font-family }" keep-with-next="always" text-transform="uppercase" font-size="{ $small }">
+      <xsl:copy-of select="@id"/>
+      <xsl:apply-templates/>
+    </fo:block>
+  </xsl:template>
+  
   <xsl:template match="div[@class='family-tableC']">
     <fo:block-container space-before="1em" page-break-before="always">
       <xsl:copy-of select="@id"/>

--- a/publish/nist-emulation/rev5update-emulator_fo.xsl
+++ b/publish/nist-emulation/rev5update-emulator_fo.xsl
@@ -297,7 +297,12 @@ TO DO:
     <xsl:attribute name="font-weight">bold</xsl:attribute>
     <xsl:next-match/>
   </xsl:template>
-  
+
+  <xsl:template mode="enhance-AppC-cell" match="td[@class='control-title']" priority="98">
+    <xsl:attribute name="font-weight">bold</xsl:attribute>
+    <xsl:next-match/>
+  </xsl:template>
+
   <xsl:template name="process-style"><xsl:param name="style"/></xsl:template>
   
   <!--<td class="control-no">-->

--- a/publish/nist-emulation/rev5update-emulator_fo.xsl
+++ b/publish/nist-emulation/rev5update-emulator_fo.xsl
@@ -187,6 +187,37 @@ TO DO:
     </fo:block-container>
   </xsl:template>
   
+  <xsl:template match="div[contains-token(@class,'control')]">
+    <xsl:variable name="enhancement" select="ancestor::div/tokenize(@class,'\s+')='control'"/>
+    <fo:block space-before="1em">
+      <xsl:copy-of select="@id"/>
+      <fo:list-block provisional-distance-between-starts="{ if ($enhancement) then '0.3' else '0.5' }in"
+        provisional-label-separation="1em"  space-before="0.5em">
+        <fo:list-item space-before="0.5em">
+          <fo:list-item-label>
+            <fo:block font-weight="bold" font-family="{ $label-font-family }" font-size="{ $big }">
+              <!--forcing a link in here b/c stripped from value -->
+              <xsl:variable name="tableC-target" select="details/summary/span[@class='label']/a/@href/substring-after(.,'#')"/>
+              <fo:basic-link color="blue" internal-destination="{ $tableC-target }">
+                <xsl:choose>
+                  <xsl:when test="$enhancement">
+                    <xsl:value-of select="replace(details/summary/span[1],'^[^\(]+','')"/>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:value-of select="details/summary/span[@class='label']"/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </fo:basic-link>
+            </fo:block>
+          </fo:list-item-label>
+          <fo:list-item-body start-indent="body-start()">
+            <xsl:apply-templates select="." mode="control-contents"/>
+          </fo:list-item-body>
+        </fo:list-item>
+      </fo:list-block>
+    </fo:block>
+  </xsl:template>
+  
   <xsl:template match="span[@class='tableC-no']">
     <fo:inline-container width="0.5in">
       <fo:block>
@@ -244,7 +275,8 @@ TO DO:
   </xsl:template>
 
   <xsl:template mode="enhance-AppC-cell" match="tr[ends-with(@class,'withdrawn')]/*" priority="101">
-    <xsl:attribute name="color">darkgrey</xsl:attribute>
+    <!--<xsl:attribute name="color">black</xsl:attribute>-->
+    <xsl:attribute name="background-color">gainsboro</xsl:attribute>
     <xsl:next-match/>
   </xsl:template>
   
@@ -257,6 +289,8 @@ TO DO:
     <xsl:attribute name="font-weight">bold</xsl:attribute>
     <xsl:next-match/>
   </xsl:template>
+  
+  <xsl:template name="process-style"><xsl:param name="style"/></xsl:template>
   
   <!--<td class="control-no">-->
   <xsl:template match="*" mode="enhance-AppC-cell">

--- a/publish/nist-emulation/rev5update_html.xsl
+++ b/publish/nist-emulation/rev5update_html.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    xmlns:o="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns="http://www.w3.org/1999/xhtml"
     xpath-default-namespace="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns:o="http://csrc.nist.gov/ns/oscal/1.0"

--- a/publish/nist-emulation/rev5update_html.xsl
+++ b/publish/nist-emulation/rev5update_html.xsl
@@ -2,7 +2,6 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:math="http://www.w3.org/2005/xpath-functions/math"
-    xmlns:o="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns="http://www.w3.org/1999/xhtml"
     xpath-default-namespace="http://csrc.nist.gov/ns/oscal/1.0"
     xmlns:o="http://csrc.nist.gov/ns/oscal/1.0"


### PR DESCRIPTION
This work is part of usnistgov/oscal-content#134. I will not explicitly link it for now as to not close the issue. I will work with wendell to 1) merge this code here, and then 2) merge it upstream to main in [the upstream origin repo](https://github.com/usnistgov/oscal-xslt.git) accordingly.